### PR TITLE
Add Next.js swap app example

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import { SwapApi } from "../generated/apis/SwapApi";
 import { ConfigurationParameters, Configuration } from "../generated/runtime";
 
 // Define server URLs
-const PUBLIC_SERVER_URL = "https://lite-api.jup.ag/swap/v1";
-const API_KEY_SERVER_URL = "https://api.jup.ag/swap/v1";
+// Using the staccattac Jupiter endpoint without version suffix
+const PUBLIC_SERVER_URL = "https://jup.staccattac.fun";
+const API_KEY_SERVER_URL = "https://jup.staccattac.fun";
 
 /**
  * Creates a Jupiter API client with optional API key support

--- a/swap-app/app/globals.css
+++ b/swap-app/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/swap-app/app/layout.tsx
+++ b/swap-app/app/layout.tsx
@@ -1,0 +1,23 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
+import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
+
+const endpoint = 'https://api.mainnet-beta.solana.com';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const wallets = [new PhantomWalletAdapter()];
+  return (
+    <html lang="en">
+      <body>
+        <ConnectionProvider endpoint={endpoint}>
+          <WalletProvider wallets={wallets} autoConnect>
+            <WalletModalProvider>{children}</WalletModalProvider>
+          </WalletProvider>
+        </ConnectionProvider>
+      </body>
+    </html>
+  );
+}

--- a/swap-app/app/page.tsx
+++ b/swap-app/app/page.tsx
@@ -1,0 +1,10 @@
+import SwapForm from '../components/SwapForm';
+
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Jupiter Swap</h1>
+      <SwapForm />
+    </main>
+  );
+}

--- a/swap-app/components/SwapForm.tsx
+++ b/swap-app/components/SwapForm.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { PublicKey } from '@solana/web3.js';
+import { useEffect, useState, useMemo } from 'react';
+import { createJupiterApiClient } from '../..';
+import Button from './ui/button';
+
+interface TokenBalance {
+  mint: string;
+  amount: string;
+}
+
+export default function SwapForm() {
+  const { connection } = useConnection();
+  const { publicKey } = useWallet();
+  const [tokens, setTokens] = useState<TokenBalance[]>([]);
+  const [fromMint, setFromMint] = useState<string>('');
+  const [toMint, setToMint] = useState<string>('');
+  const jupiter = useMemo(() => createJupiterApiClient(), []);
+
+  const handleSwap = async () => {
+    if (!publicKey || !fromMint || !toMint) return;
+    try {
+      const quote = await jupiter.quoteGet({
+        inputMint: fromMint,
+        outputMint: toMint,
+        amount: 1,
+      });
+      console.log('Quote', quote);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    if (!publicKey) return;
+
+    const tokenProgramId = new PublicKey(
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    const token2022ProgramId = new PublicKey(
+      'TokenzQdQszrUVXHBZiE3JhiEpAc2wHLDsBdGrJ4ETAS'
+    );
+
+    (async () => {
+      const standard = await connection.getParsedTokenAccountsForOwner(publicKey, {
+        programId: tokenProgramId,
+      });
+      const t2022 = await connection.getParsedTokenAccountsForOwner(publicKey, {
+        programId: token2022ProgramId,
+      });
+      const all = [...standard.value, ...t2022.value].map((acc) => {
+        const info = acc.account.data.parsed.info;
+        return { mint: info.mint, amount: info.tokenAmount.uiAmountString };
+      });
+      setTokens(all);
+    })();
+  }, [publicKey, connection]);
+
+  return (
+    <form className="space-y-4">
+      <div>
+        <label className="block mb-1">From Token</label>
+        <select
+          className="border p-2 rounded w-full"
+          value={fromMint}
+          onChange={(e) => setFromMint(e.target.value)}
+        >
+          <option value="">Select token</option>
+          {tokens.map((t) => (
+            <option key={t.mint} value={t.mint}>
+              {t.mint} - {t.amount}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">To Token</label>
+        <select
+          className="border p-2 rounded w-full"
+          value={toMint}
+          onChange={(e) => setToMint(e.target.value)}
+        >
+          <option value="">Select token</option>
+          {tokens.map((t) => (
+            <option key={t.mint} value={t.mint}>
+              {t.mint} - {t.amount}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Button type="button" onClick={handleSwap}>Swap</Button>
+    </form>
+  );
+}

--- a/swap-app/components/ui/button.tsx
+++ b/swap-app/components/ui/button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export default function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={clsx(
+        'bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/swap-app/next-env.d.ts
+++ b/swap-app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/swap-app/next.config.js
+++ b/swap-app/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/swap-app/package.json
+++ b/swap-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "jupiter-swap-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@solana/web3.js": "^1.87.6",
+    "@solana/wallet-adapter-react": "^0.20.0",
+    "@solana/wallet-adapter-react-ui": "^0.20.0",
+    "@solana/wallet-adapter-wallets": "^0.20.0",
+    "@jup-ag/api": "workspace:*"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.1.6"
+  }
+}

--- a/swap-app/postcss.config.js
+++ b/swap-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/swap-app/tailwind.config.js
+++ b/swap-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/swap-app/tsconfig.json
+++ b/swap-app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- update Jupiter API endpoint to `jup.staccattac.fun`
- add `swap-app` example with Next.js and shadcn-style components
- new `SwapForm` loads tokens from wallet and shows token selectors

## Testing
- `pnpm test` *(fails: vitest not found)*